### PR TITLE
Fix Commitizen version file reference

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,6 @@ version = "0.8.0"
 tag_format = "v$version"
 version_files = [
     "pyproject.toml:version",
-    "ai3_diagrams_expert/__init__.py:__version__"
+    "src/__init__.py:__version__"
 ]
 update_changelog_on_bump = true

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,5 @@
+"""Top-level package for sample Bedrock Chainlit MCP."""
+
+__all__ = ["__version__"]
+
+__version__ = "0.1.0"


### PR DESCRIPTION
## Summary
- update Commitizen configuration to reference the actual package `__version__`
- define the package version constant in `src/__init__.py`

## Testing
- uv run cz bump --dry-run *(fails: unable to download dependency due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68d6932e2f10832b96d5f37f40fd3d92